### PR TITLE
Fix: add missing ArduinoJson dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,8 @@ platform = espressif8266
 board = nodemcuv2
 framework = arduino
 board_build.filesystem = littlefs
+lib_deps = 
+	bblanchon/ArduinoJson@7.0.1
 
 [platformio]
 data_dir = interface/dist


### PR DESCRIPTION
The dependency ArduinoJson was missing in platformio.ini, so I couldn't build the project. This PR adds it.