### PR TITLE
Feat: add exception decoder monitor filter

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ platform = espressif8266
 board = nodemcuv2
 framework = arduino
 board_build.filesystem = littlefs
+monitor_filters = esp8266_exception_decoder, colorize
 
 [platformio]
 data_dir = interface/dist


### PR DESCRIPTION
This PR adds a `monitor_filters` section in `platformio.ini`, containing `esp8266_exception_decoder` for decoding possible exceptions that come from Serial Monitor (without it exceptions come encoded and unreadable), and `colorize` for distinguishing output from the terminal and from the serial monitor itself.