### PR TITLE
Feat: Frontent inside PROGMEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ This project is a simple template to start a new project with Preact, tailwind a
 3. Omit the secret `SECRET_JWT` for disabling authentication.
 4. Install the dependencies inside the `interface` folder with `yarn`
 5. Run `yarn build` to build the interface
-6. Build and upload the file system image with `pio run -t buildfs && pio run -t uploadfs`, or use the [PlatformIO IDE](https://randomnerdtutorials.com/esp32-vs-code-platformio-spiffs/)
-7. Build and upload the code with `pio run -t upload` or use the PlatformIO IDE.
-8. Open the serial monitor to see the IP address of the ESP8266 and access it on your browser.
+6. Build and upload the code with `pio run -t upload` or use the PlatformIO IDE.
+7. Open the serial monitor to see the IP address of the ESP8266 and access it on your browser.
 
 ### Development
 

--- a/interface/package.json
+++ b/interface/package.json
@@ -14,6 +14,7 @@
 		"uuid": "^10.0.0"
 	},
 	"devDependencies": {
+		"@ikoz/vite-plugin-preact-esp32": "^0.1.0",
 		"@preact/preset-vite": "^2.5.0",
 		"@types/node": "^22.1.0",
 		"@types/uuid": "^10.0.0",

--- a/interface/vite.config.ts
+++ b/interface/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
+import { espViteBuild } from "@ikoz/vite-plugin-preact-esp32";
 import "dotenv/config";
 
 const proxyTarget: string | undefined = process.env.VITE_PROXY;
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [preact()],
+  plugins: [espViteBuild(), preact()],
   resolve: {
     alias: {
       "@components": "/src/components",

--- a/interface/yarn.lock
+++ b/interface/yarn.lock
@@ -420,6 +420,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
+"@ikoz/vite-plugin-preact-esp32@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@ikoz/vite-plugin-preact-esp32/-/vite-plugin-preact-esp32-0.1.0.tgz#d0f76ffdfb1daffd7ee1da0939a0b72be26be001"
+  integrity sha512-lgSSlsgD7LiiLLJJrsDQGytLilMCSrQmaCU3qKjUkENo8XMwoKvwd8IDrVzMTnAI44f32lgjnp7f9NJCAjk+Qw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,4 +26,4 @@ lib_deps =
 	bblanchon/ArduinoJson@7.1.0
 
 [platformio]
-data_dir = interface/dist
+include_dir = interface/dist/_esp32


### PR DESCRIPTION
This PR adds support for uploading all frontend files to PROGMEM. With this, uploading the filesystem isn't needed, thus it won't be erased and will retain modified data.

Now the web server priority is at follows:
Route declared with `server.on` > File inside PROGMEM > File inside FS > `index.html` from PROGMEM

Note that it won't run `yarn build` in `interface/` automatically, so this step is still required.

This implementation was done using the Vite plugin https://github.com/isaackoz/vite-plugin-preact-esp32