### PR TITLE
feat: auto builds interface before main on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ This project is a simple template to start a new project with Preact, tailwind a
 1. Clone this repository
 2. Create a `secrets.h` file inside the `src` using the `secrets.h.example` as a template. This file will contain the WiFi credentials.
 3. Omit the secret `SECRET_JWT` for disabling authentication.
-4. Install the dependencies inside the `interface` folder with `yarn`
-5. Run `yarn build` to build the interface
-6. Build and upload the code with `pio run -t upload` or use the PlatformIO IDE.
-7. Open the serial monitor to see the IP address of the ESP8266 and access it on your browser.
+4. Build and upload the code with `pio run -t upload` or use the PlatformIO IDE.
+5. Open the serial monitor to see the IP address of the ESP8266 and access it on your browser.
 
 ### Development
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,8 @@
 ;  --auth=1234 ; password
 ; upload_port = 192.168.0.185
 ; upload_protocol = espota
+extra_scripts = 
+ pre:scripts/build_interface.py
 
 [env:nodemcuv2]
 platform = espressif8266

--- a/scripts/build_interface.py
+++ b/scripts/build_interface.py
@@ -1,0 +1,20 @@
+import os
+
+Import("env")
+
+def build_web_interface():
+  os.chdir('interface')
+  print("Building interface with yarn")
+
+  try:
+    env.Execute('yarn install')
+    env.Execute('yarn build')
+    
+  except:
+    print("Error building interface")
+    exit(1)
+
+  finally:
+    os.chdir('..')
+
+build_web_interface()


### PR DESCRIPTION
This PR enhances the build process by automating the interface compilation. It introduces a Python script that runs automatically before the main compilation process, triggered by an upload request. This addition eliminates the need for a manual interface build step.